### PR TITLE
Add root option to loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ require('ng-cache?prefix=public/[dir]//[dir]/templates!./far/far/away/path/to/my
 // => ng-include="'public/far/path/templates/myPartial.html'" 
 ```
 
+## Root
+
+With `root` param you can specify which directory in the template path is the root, from which the template path should be created:
+
+``` javascript
+require('ng-cache?root=app!./js/app/module/myPartial.html')
+// => ng-include="'module/myPartial.html'"
+```
+
 ## webpack config
 
 Match `.html` extension with loader:

--- a/lib/templateId.js
+++ b/lib/templateId.js
@@ -12,10 +12,15 @@ module.exports = function () {
         prefix,
         dir,
         i;
-
-    if (!query.prefix) {
+    if (!(query.prefix || query.root)) {
         return fileName;
     }
+
+    if (query.root) {
+        index = resource.indexOf(query.root);
+        return resource.slice(index + 1).concat(fileName).join('/');
+    }
+
     resource.reverse();
     prefix = query.prefix.split(path.sep);
     i = prefix.length;


### PR DESCRIPTION
Hi! 

I've needed for ng-cache-loader to write templates with the actual path in the project:

```
├── app
│   ├── angular.js
│   ├── app.js
│   ├── core.js
│   ├── landing
│   │   ├── landing.jade
│   │   └── landing.js
│   ├── shared
│   │   ├── shared.js
│   │   └── templates
│   │       └── header.jade
│   ├── styles.js
│   └── views
│       └── layouts
│           ├── app.jade
│           ├── frontend.jade
│           └── header.jade
```

So with the following structure, I expected my template urls to look like this `landing/landing.jade` and `shared/templates/header.jade`

I've decided to add a `root` param to the loader config which will specify, which directory name, in the file's path, should be used as the root, from which the url is generated.

Let me know what you think and if it's something that you are willing to merge in the project.

If you have any feedback about the code, feel free to point it out!

Best regards,
Szymon Szeliga