### PR TITLE
Add optional 'module' parameter to register templates using a different module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ require('ng-cache?prefix=public/[dir]//[dir]/templates!./far/far/away/path/to/my
 // => ng-include="'public/far/path/templates/myPartial.html'" 
 ```
 
+## Module
+
+By default, templates will be added to the default AngularJS 'ng' module run() method. 
+Use this parameter to use a different module name:
+
+``` javascript
+require('ng-cache?module=moduleName!./path/to/myPartial.html')
+```
+
 ## webpack config
 
 Match `.html` extension with loader:

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var urlParser = require('./lib/urlParser.js');
 var getTemplateId = require('./lib/templateId.js');
 
 var stub = 'var v$i=$val;\n' +
-    'window.angular.module(["ng"])' +
+    'window.angular.module(["$mod"])' +
     '.run(["$templateCache",function(c){' +
     'c.put("$key", v$i)' +
     '}]);';
@@ -28,6 +28,8 @@ module.exports = function (source) {
     };
 
     this.cacheable && this.cacheable();
+
+    var mod = query.module || 'ng';
 
     source = htmlMinifier.minify(source, {
         removeComments: true,
@@ -50,6 +52,7 @@ module.exports = function (source) {
             .join('');
         if (scr.id) {
             result.push({
+                mod: mod,
                 key: scr.id,
                 val: resolveUrl(html),
                 i: result.length + 1
@@ -62,6 +65,7 @@ module.exports = function (source) {
     source = source.join('');
     if (/[^\s]/.test(source)) {
         result.push({
+            mod: mod,
             key: getTemplateId.apply(this),
             val: resolveUrl(source),
             i: result.length + 1


### PR DESCRIPTION
At the moment, all templates are loaded into the implicit AngularJS 'ng' module. This works fine for applications that are built into a single assembly, but can be problematic if the templates are loaded dynamically - This happens if app modules are loaded after the application is already running (e.g. by using ocLazyLoad), since the ```module.run()``` method has already been executed.

By adding a new ```module``` parameter that allows the developer to define a custom module name, we can change the name of the template module to something other than 'ng' (i.e. the name of the lazy-loaded module).

Then when the new module is lazy-loaded the templates will be correctly registered by the new module's run() method.

For backward compatibility, the module name will default to 'ng' unless the module parameter is specified in the loader query.