### PR TITLE
Add exportIdOnly to make it compatible with file-loader interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,16 @@ If the module does not exist it is created.
 
 ## Template id
  
-To obtain template id use `exportId` query parameter. Loader exports object with `id` and `template` keys.
+To obtain template id use `exportIdOnly` query parameter. Loader exports `id` of a template.
+
+```javascript
+var template = require('ng-cache?exportIdOnly!./field.html')
+
+$('#wrapper').html(`<div id="bootstrapElement" data-ng-include="'${template}'"></div>`);
+angular.bootstrap($('#bootstrapElement'), [someModule]);
+```
+
+To obtain both template id and html partial use `exportId` query parameter. Loader exports object with `id` and `template` keys.
 
 ```javascript
 var template = require('ng-cache?exportId!./field.html')

--- a/index.js
+++ b/index.js
@@ -116,6 +116,8 @@ module.exports = function(source) {
     // Return template string or id/template pair as module exports
     if (opts.exportId) {
         result.push('exports.id=id' + result.length + ';\nexports.template=v' + result.length + ';');
+    } else if (opts.exportIdOnly) {
+        result.push('module.exports=id' + result.length + ';');
     } else {
         result.push('module.exports=v' + result.length + ';');
     }


### PR DESCRIPTION
It would be so easy to switch between cached templates and separated templates if the interface of `ng-cache-loader` would be same with `file-loader`.

```javascript
// webpack.config.js

module.exports = {
  // ...
  module: {
    loaders: [
      {
        test: /\.html$/,
        loaders: [
          'file?name=[path][name].[ext]',
          'extract',
          'html'
        ]
      }
    ]
  }
};
```

In the example above templates are loaded with `file-loader`. If I want to upgrade my application with `ng-cache-loader` I will change this file:

```javascript
// webpack.config.js

// Angular templates are stored under this directory
const angularComponentsMatch = /\/src\/components\/.*\.html$/;

module.exports = {
  // ...
  module: {
    loaders: [
      {
        test: angularComponentsMatch,
        loader: 'ng-cache?prefix=src:/components/**&exportId'
      },
      {
        test: /\.html$/,
        // Exclude Angular components so file-loader won't process them
        exclude: angularComponentsMatch,
        loaders: [
          'file?name=[path][name].[ext]',
          'extract',
          'html'
        ]
      }
    ]
  }
};
```

I'm using `templateUrl` property for `routes` and `components` in my application, so I have to add `id` property for each loaded HTML-module:

```javascript
// my-component.js

// ...
module.component('myComponent', {
  templateUrl: require('./my-component.html').id
});
```

It is overhead.
What if I want to exclude just part of my templates? I have to change specific only files, and I have to explain it to all of the contributors in some way.

By adding `extractIdOnly` property HTML modules will return a string instead of the object with `id` property. As a result, application files don't need to be modified. Developers can even configure webpack to process different templates depends on dynamic settings.