### PR TITLE
Provide minimize query parameter to allow using different minification libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ and the [manual](https://webpack.github.io/docs/using-loaders.html#loaders-in-re
 
 ## HTML minification
 
+Minification is enabled by default. You can switch it off by setting `minimize` query parameter to `false`:
+```javascript
+ng-cache?minimize=false
+```
+
 The [html-minifier](https://github.com/kangax/html-minifier) is used for templates minification with the default options:
 ```javascript
 {

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ and the [manual](https://webpack.github.io/docs/using-loaders.html#loaders-in-re
 
 ## HTML minification
 
-Minification is enabled by default. You can switch it off by setting `minimize` query parameter to `false`:
+Minification is enabled by default. You can switch it off by setting `-minimize`:
 ```javascript
-ng-cache?minimize=false
+ng-cache?-minimize
 ```
 
 The [html-minifier](https://github.com/kangax/html-minifier) is used for templates minification with the default options:

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ function resolveUrl(query, src) {
 module.exports = function(source) {
     var opts = {
         module: 'ng',
+        minimize: true,
         // next are html-minifier default options
         removeComments: true,
         removeCommentsFromCDATA: true,
@@ -75,10 +76,12 @@ module.exports = function(source) {
     // Parse query and append minimize options
     extend(opts, minimizeOpts, loaderUtils.parseQuery(this.query));
 
-    try {
-        source = htmlMinifier.minify(source, extend({}, opts));
-    } catch (e) {
-        this.emitWarning(e.toString() + '\nUsing unminified HTML');
+    if (opts.minimize) {
+        try {
+            source = htmlMinifier.minify(source, extend({}, opts));
+        } catch (e) {
+            this.emitWarning(e.toString() + '\nUsing unminified HTML');
+        }
     }
 
     scripts = scriptParser.parse('root', source, {scripts: []}).scripts;


### PR DESCRIPTION
With the parameter `minimize` (has `true`value by default) I can turn off integrated minification and use global configuration for `html-minifier` or even a different library for this issue.