### PR TITLE
added injector to load $templateCache for dynamic chunks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,10 @@ var PRE_STUB = 'var angular=window.angular,ngModule;\n' +
 
 var STUB = 'var v${i}=${val};\n' +
     'var id${i}="${key}";\n' +
-    'ngModule.run(["$templateCache",function(c){c.put(id${i},v${i})}]);';
+    // added injector to load $templateCache for dynamic chunks
+    'var inj=angular.element(window.document).injector();\n' +
+    'if(inj){inj.get("$templateCache").put(id${i},v${i});}\n' +
+    'else{ngModule.run(["$templateCache",function(c){c.put(id${i},v${i})}]);}';
 
 /**
  * Replaces placeholders with values.


### PR DESCRIPTION
ng-cache is not working for dynamic chunks, since `ngModule.run()` only executes before app bootstrap.
so i added this `injector` method to get `$templateCache` for document module and put the template in it same way it does with `ngModule`. 

so the all initial load templates will use existing logic since `angular.element(window.document).injector()` is `undefined` before bootstrap and it is available for dynamic chunks/modules when loaded after bootstrap.