### PR TITLE
Add support for Angular Material <md-icon> directive

### DIFF
--- a/lib/urlParser.js
+++ b/lib/urlParser.js
@@ -10,7 +10,7 @@ Parser = new Parser({
         '<[^\\s/>]+': 'tag',
     },
     tag: {
-        '[\\s\\n]src[\\s\\n]*=[\\s\\n]*[\'"]': 'srcAttr',
+        '[\\s\\n](md-svg-)?src[\\s\\n]*=[\\s\\n]*[\'"]': 'srcAttr',
         '>': 'root',
     },
     srcAttr: {


### PR DESCRIPTION
Add support for Angular Material <md-icon> directive, by adding md-svg-src to urlParser's tag regex.
Example usage:
 <md-icon md-svg-src="/android.svg" aria-label="android "></md-icon>
Also see https://material.angularjs.org/latest/api/directive/mdIcon